### PR TITLE
pin exact version for html5ever

### DIFF
--- a/native/html5ever_nif/Cargo.toml
+++ b/native/html5ever_nif/Cargo.toml
@@ -12,7 +12,7 @@ crate-type = ["dylib"]
 [dependencies]
 rustler = "^0.21"
 
-html5ever = "0.25.0"
+html5ever = "=0.25.0"
 markup5ever = "0.10"
 
 tendril = "0.4"


### PR DESCRIPTION
`^` is the default version specifier, which allows patch version
upgrades. To pin the version properly, we need to use `=`.